### PR TITLE
Adds header as an option to new_request

### DIFF
--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -44,6 +44,11 @@ defmodule Stripe.Request do
   """
   @spec new_request(Stripe.options(), map) :: t
   def new_request(opts \\ [], headers \\ %{}) do
+    headers =
+      opts
+      |> Keyword.get(:headers, %{})
+      |> Map.merge(headers)
+
     %Request{opts: opts, headers: headers}
   end
 

--- a/test/stripe/request_test.exs
+++ b/test/stripe/request_test.exs
@@ -27,4 +27,14 @@ defmodule Stripe.RequestTest do
       assert request.opts == opts
     end
   end
+
+  describe "new_request/2" do
+    test "new_request/1 extracts headers from options and puts it on headers" do
+      new_request = Request.new_request([headers: %{foo: "bar"}])
+
+      assert new_request.headers == %{
+        foo: "bar"
+      }
+    end
+  end
 end


### PR DESCRIPTION
This had to be done instead of extracting out the headers in options for
all functions that call request.