### PR TITLE
Erlang/OTP 24 compatibility (:crypto.hmac -> :crypto.mac)

### DIFF
--- a/lib/stripe/webhook.ex
+++ b/lib/stripe/webhook.ex
@@ -116,7 +116,7 @@ defmodule Stripe.Webhook do
   end
 
   defp compute_signature(payload, secret) do
-    :crypto.hmac(:sha256, secret, payload)
+    :crypto.mac(:hmac, :sha256, secret, payload)
     |> Base.encode16(case: :lower)
   end
 


### PR DESCRIPTION
:crypto.hmac/3 was removed in erlang 24 but the same functionality is available in :crypto.mac/4