### PR TITLE
Remove `customer` from  upcoming invoice

### DIFF
--- a/lib/stripe/subscriptions/invoice.ex
+++ b/lib/stripe/subscriptions/invoice.ex
@@ -184,7 +184,7 @@ defmodule Stripe.Invoice do
   Retrieve an upcoming invoice.
   """
   @spec upcoming(map, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
-  def upcoming(params = %{customer: _customer}, opts \\ []) do
+  def upcoming(params, opts \\ []) do
     new_request(opts)
     |> put_endpoint(@plural_endpoint <> "/upcoming")
     |> put_method(:get)


### PR DESCRIPTION
Removing `customer` as a required field when calling `Invoice.upcoming/2`. 

Reasoning:
There are cases where we don't want to preview an invoice as a customer. Looking at the documentation https://stripe.com/docs/api/invoices/upcoming#upcoming_invoice-customer, it's also marked as an optional field.