### PR TITLE
Update to the upstream v2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ otp_release:
 sudo: false
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.30.0
+    - STRIPE_MOCK_VERSION=0.38.0
     - MIX_ENV=test STRIPE_SECRET_KEY=non_empty_secret_key_string
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Latest
 
+## 2.2.2
+
+- [Upgrade stripe-mock 0.38](https://github.com/code-corps/stripity_stripe/pull/436)
+- *New Feature:* [Add delete endpoint to Invoiceitems](https://github.com/code-corps/stripity_stripe/pull/434)
+- [Ensure tests wait until stripe_mock started](https://github.com/code-corps/stripity_stripe/pull/427)
+- [Upgraded erlexec for OTP 21 support](https://github.com/code-corps/stripity_stripe/pull/426)
+- [Added missing invoice attributes](https://github.com/code-corps/stripity_stripe/pull/425)
+- [Enabled Dialyxir in CI](https://github.com/code-corps/stripity_stripe/pull/424)
+
 ## 2.2.1
 
 - [Fix: date_query type had fields incorrectly marked as mandatory](https://github.com/code-corps/stripity_stripe/pull/421)

--- a/lib/stripe/subscriptions/invoiceitem.ex
+++ b/lib/stripe/subscriptions/invoiceitem.ex
@@ -117,6 +117,19 @@ defmodule Stripe.Invoiceitem do
   end
 
   @doc """
+  Delete and invoiceitem
+
+  Takes the `id` of the invoiceitem to delete.
+  """
+  @spec delete(Stripe.id() | t, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  def delete(id, opts \\ []) do
+    new_request(opts)
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:delete)
+    |> make_request()
+  end
+
+  @doc """
   List all invoiceitems.
   """
   @spec list(params, Stripe.options()) :: {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Stripe.Mixfile do
         "coveralls.html": :test
       ],
       test_coverage: [tool: ExCoveralls],
-      version: "2.2.1",
+      version: "2.2.2",
       source_url: "https://github.com/code-corps/stripity_stripe/"
     ]
   end

--- a/test/stripe/core_resources/file_upload_test.exs
+++ b/test/stripe/core_resources/file_upload_test.exs
@@ -14,14 +14,14 @@ defmodule Stripe.FileUploadTest do
 
   describe "retrieve/2" do
     test "retrieves an file" do
-      assert {:ok, %Stripe.FileUpload{}} = Stripe.FileUpload.retrieve("file_123")
+      assert {:ok, _} = Stripe.FileUpload.retrieve("file_123")
       assert_stripe_requested :get, "/v1/files/file_123"
     end
   end
 
   describe "list/2" do
     test "lists all files" do
-      assert {:ok, %Stripe.List{data: [%Stripe.FileUpload{}]}} = Stripe.FileUpload.list()
+      assert {:ok, _} = Stripe.FileUpload.list()
       assert_stripe_requested :get, "/v1/files"
     end
   end

--- a/test/stripe/payment_methods/source_test.exs
+++ b/test/stripe/payment_methods/source_test.exs
@@ -24,7 +24,7 @@ defmodule Stripe.SourceTest do
 
   describe "attach/2" do
     test "attaches a source to a customer" do
-      assert {:ok, %Stripe.BankAccount{}} =
+      assert {:ok, _} =
                Stripe.Source.attach(%{customer: "cus_123", source: "src_123"})
 
       assert_stripe_requested(:post, "/v1/customers/cus_123/sources")
@@ -33,7 +33,7 @@ defmodule Stripe.SourceTest do
 
   describe "detach/2" do
     test "detaches a source from a customer" do
-      assert {:ok, %Stripe.BankAccount{}} =
+      assert {:ok, %{deleted: true, id: "src_123"}} =
                Stripe.Source.detach("src_123", %{customer: "cus_123"})
 
       assert_stripe_requested(:delete, "/v1/customers/cus_123/sources/src_123")

--- a/test/stripe/subscriptions/invoiceitem_test.exs
+++ b/test/stripe/subscriptions/invoiceitem_test.exs
@@ -10,16 +10,24 @@ defmodule Stripe.InvoiceitemTest do
 
   describe "retrieve/2" do
     test "retrieves an invoice" do
-      assert {:ok, %Stripe.Invoiceitem{}} = Stripe.Invoiceitem.retrieve("in_1234")
+      assert {:ok, %Stripe.Invoiceitem{}} = Stripe.Invoiceitem.retrieve("ii_1234")
       assert_stripe_requested(:get, "/v1/invoiceitems/in_1234")
     end
   end
 
-  describe "update/2" do
+  describe "update/3" do
     test "updates an invoice" do
       params = %{metadata: %{key: "value"}}
-      assert {:ok, %Stripe.Invoiceitem{}} = Stripe.Invoiceitem.update("in_1234", params)
+      assert {:ok, %Stripe.Invoiceitem{}} = Stripe.Invoiceitem.update("ii_1234", params)
       assert_stripe_requested(:post, "/v1/invoiceitems/in_1234")
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes an invoice" do
+      {:ok, invoiceitem} = Stripe.Invoiceitem.retrieve("ii_1234")
+      assert {:ok, _} = Stripe.Invoiceitem.delete("ii_1234")
+      assert_stripe_requested(:delete, "/v1/invoiceitems/#{invoiceitem.id}")
     end
   end
 


### PR DESCRIPTION
This PR updates our stripity_stripe fork to v2.2.2. This is part of an effort to bring our forked version of the library closer to the latest upstream version of the library.