### PR TITLE
Update to the upstream v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Latest
 
+## 2.7.0
+
+- 💜 @ishikawa [Add idempotent requests](https://github.com/code-corps/stripity_stripe/pull/546)
+- [Fix source amount field type](https://github.com/code-corps/stripity_stripe/pull/545)
+
 ## 2.6.0
 
 - [Add support for SetupIntent](https://github.com/code-corps/stripity_stripe/pull/522)

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ config :stripity_stripe, secret_key: "YOUR SECRET KEY"
 config :stripity_stripe, platform_client_id: "YOUR CONNECT PLATFORM CLIENT ID"
 ```
 
+
 ## Testing
 
 If you start contributing and you want to run mix test, first you need to export STRIPE_SECRET_KEY environment variable in the same shell as the one you will be running mix test in. All tests have the @tag disabled: false and the test runner is configured to ignore disabled: true. This helps to turn tests on/off when working in them. Most of the tests depends on the order of execution (test random seed = 0) to minimize runtime. I've tried having each tests isolated but this made it take ~10 times longer.
@@ -310,4 +311,4 @@ As I began digging things up with these other libraries it became rather apparen
 
 ## Update
 
-As of October 18th, Rob has graciously handed over the reins to the teams at [Code Corps](https://www.codecorps.org/) and [Strumber](https://strumber.com/). To addresses the concerns Rob mentioned above and update the high level api to work with all of the Stripe API Endpoints, they have since worked to release and stripity_stripe 2.0, which is now the actively developed line of releases.
+As of October 18th, Rob has graciously handed over the reins to the teams at [Code Corps](https://www.codecorps.org/) and [Strumber](https://strumber.com/). To address the concerns Rob mentioned above and update the high level api to work with all of the Stripe API Endpoints, they have since worked to release stripity_stripe 2.0, which is now the actively developed line of releases.

--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -28,15 +28,6 @@ defmodule Stripe.API do
     Config.resolve(:json_library, Jason)
   end
 
-  @doc """
-  In config.exs your implicit or expicit configuration is:
-    config :stripity_stripe,
-      json_library: Jason # defaults to Poison but can be configured to Jason
-  """
-  def json_library() do
-    Application.get_env(:stripity_stripe, :json_library, Poison)
-  end
-
   def supervisor_children do
     if use_pool?() do
       [:hackney_pool.child_spec(@pool_name, get_pool_options())]

--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -28,6 +28,15 @@ defmodule Stripe.API do
     Config.resolve(:json_library, Jason)
   end
 
+  @doc """
+  In config.exs your implicit or expicit configuration is:
+    config :stripity_stripe,
+      json_library: Jason # defaults to Poison but can be configured to Jason
+  """
+  def json_library() do
+    Application.get_env(:stripity_stripe, :json_library, Poison)
+  end
+
   def supervisor_children do
     if use_pool?() do
       [:hackney_pool.child_spec(@pool_name, get_pool_options())]

--- a/lib/stripe/payment_methods/source.ex
+++ b/lib/stripe/payment_methods/source.ex
@@ -169,7 +169,7 @@ defmodule Stripe.Source do
           ach_credit_transfer: ach_credit_transfer | nil,
           ach_debit: ach_debit | nil,
           alipay: alipay | nil,
-          amount: integer | nil,
+          amount: non_neg_integer | nil,
           bancontact: bancontact | nil,
           bitcoin: bitcoin | nil,
           card: card | nil,
@@ -240,7 +240,7 @@ defmodule Stripe.Source do
   @spec create(params, Keyword.t()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params: %{
                :type => String.t(),
-               optional(:amount) => String.t(),
+               optional(:amount) => non_neg_integer,
                optional(:currency) => String.t(),
                optional(:flow) => String.t(),
                optional(:mandate) => map,

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Stripe.Mixfile do
         "coveralls.html": :test
       ],
       test_coverage: [tool: ExCoveralls],
-      version: "2.6.0",
+      version: "2.7.0",
       source_url: "https://github.com/code-corps/stripity_stripe/",
       docs: [
         main: "readme",


### PR DESCRIPTION
This PR updates our stripity_stripe fork to v2.7.0. This is part of an effort to bring our forked version of the library closer to the latest upstream version of the library.

This matches all of the changes from upstream, except I added the properties back in that we are still using in massdriver.

Testing this locally by installing the commit ID from this PR.