### PR TITLE
fix warnings

### DIFF
--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -17,7 +17,7 @@ defmodule Stripe.API do
 
   @pool_name __MODULE__
   @api_version "2018-08-23"
-  @http_module Application.get_env(:stripity_stripe, :http_module) || :hackney
+  @http_module Application.compile_env(:stripity_stripe, :http_module) || :hackney
 
   def supervisor_children do
     if use_pool?() do

--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -72,7 +72,7 @@ defmodule Stripe.Converter do
   @spec convert_stripe_object(%{String.t() => any}) :: struct
   defp convert_stripe_object(%{"object" => object_name} = value) do
     module = Stripe.Util.object_name_to_module(object_name)
-    struct_keys = Map.keys(module.__struct__) |> List.delete(:__struct__)
+    struct_keys = Map.keys(module.__struct__()) |> List.delete(:__struct__)
     check_for_extra_keys(struct_keys, value)
 
     processed_map =

--- a/lib/stripe/util.ex
+++ b/lib/stripe/util.ex
@@ -79,7 +79,7 @@ defmodule Stripe.Util do
 
       quote bind_quoted: [mod: mod, fun: fun, arity: arity, msg: msg] do
         require Logger
-        Logger.warn("[DEPRECATION] The function #{mod}.#{fun}/#{arity} is deprecated. #{msg}")
+        Logger.warning("[DEPRECATION] The function #{mod}.#{fun}/#{arity} is deprecated. #{msg}")
       end
     end
   end

--- a/lib/stripe/webhook.ex
+++ b/lib/stripe/webhook.ex
@@ -132,10 +132,8 @@ defmodule Stripe.Webhook do
   defp secure_compare(acc, [], []), do: acc == 0
 
   defp secure_compare(acc, [input_codepoint | input], [expected_codepoint | expected]) do
-    import Bitwise
-
     acc
-    |> bor(input_codepoint ^^^ expected_codepoint)
+    |> bor(Bitwise.xor(input_codepoint, expected_codepoint))
     |> secure_compare(input, expected)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Stripe.Mixfile do
         plt_add_apps: [:mix],
         plt_file: {:no_warn, "priv/plts/stripity_stripe.plt"}
       ],
-      elixir: "~> 1.5",
+      elixir: "~> 1.18",
       package: package(),
       elixirc_paths: elixirc_paths(Mix.env()),
       preferred_cli_env: [


### PR DESCRIPTION
fixes these compilation warnings:
```
==> stripity_stripe
Compiling 51 files (.ex)

     warning: Application.get_env/2 is discouraged in the module body, use Application.compile_env/3 instead
     │
  20 │   @http_module Application.get_env(:stripity_stripe, :http_module) || :hackney
     │                            ~

     warning: ^^^ is deprecated. It is typically used as xor but it has the wrong precedence, use Bitwise.bxor/2 instead
     │
 138 │     |> bor(input_codepoint ^^^ expected_codepoint)
     │                            ~
     │
     └─ lib/stripe/webhook.ex:138:28

     warning: Logger.warn/1 is deprecated. Use Logger.warning/2 instead
     │
 262 │     Stripe.Util.log_deprecation("Please use `capture/3` instead.")
     │     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     │
     └─ lib/stripe/core_resources/charge.ex:262: Stripe.Charge.capture/2

     warning: Logger.warn/1 is deprecated. Use Logger.warning/2 instead
     │
 273 │     Stripe.Util.log_deprecation("Please use `capture/3` instead.")
     │     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     │
     └─ lib/stripe/core_resources/charge.ex:273: Stripe.Charge.capture/1
```

and this runtime warning:
```
warning: using map.field notation (without parentheses) to invoke function Stripe.Event.__struct__() is deprecated, you must add parentheses instead: remote.function()
  (stripity_stripe 2.2.1) lib/stripe/converter.ex:75: Stripe.Converter.convert_stripe_object/1
  (stripity_stripe 2.2.1) lib/stripe/webhook.ex:45: Stripe.Webhook.construct_event/4
```