### PR TITLE
i have shamed myself

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,4 @@
-use Mix.Config
-
 if File.exists?("config/config.secret.exs") do
+  import Config
   import_config "config.secret.exs"
 end

--- a/lib/stripe/webhook.ex
+++ b/lib/stripe/webhook.ex
@@ -133,7 +133,7 @@ defmodule Stripe.Webhook do
 
   defp secure_compare(acc, [input_codepoint | input], [expected_codepoint | expected]) do
     acc
-    |> Bitwise.bor(Bitwise.xor(input_codepoint, expected_codepoint))
+    |> Bitwise.bor(Bitwise.bxor(input_codepoint, expected_codepoint))
     |> secure_compare(input, expected)
   end
 

--- a/lib/stripe/webhook.ex
+++ b/lib/stripe/webhook.ex
@@ -133,7 +133,7 @@ defmodule Stripe.Webhook do
 
   defp secure_compare(acc, [input_codepoint | input], [expected_codepoint | expected]) do
     acc
-    |> bor(Bitwise.xor(input_codepoint, expected_codepoint))
+    |> Bitwise.bor(Bitwise.xor(input_codepoint, expected_codepoint))
     |> secure_compare(input, expected)
   end
 


### PR DESCRIPTION
```
➜  massdriver git:(me/bes-1721/bump-stripe) ✗ mix deps.compile stripity_stripe
==> stripity_stripe
Compiling 51 files (.ex)
     error: undefined function bor/2 (expected Stripe.Webhook to define such a function or for it to be imported, but none are available)
     │
 136 │     |> bor(Bitwise.xor(input_codepoint, expected_codepoint))
     │        ^^^
     │
     └─ lib/stripe/webhook.ex:136:8: Stripe.Webhook.secure_compare/3


== Compilation error in file lib/stripe/webhook.ex ==
** (CompileError) lib/stripe/webhook.ex: cannot compile module Stripe.Webhook (errors have been logged)
```
i promise i actually compiled it this time :X who knew we didn't have CI, hah