### PR TITLE
[MON-1934] rename Stripe.Customer "account_balance" to "balance"

### DIFF
--- a/lib/stripe/core_resources/customer.ex
+++ b/lib/stripe/core_resources/customer.ex
@@ -18,8 +18,8 @@ defmodule Stripe.Customer do
   @type t :: %__MODULE__{
           id: Stripe.id(),
           object: String.t(),
-          account_balance: integer,
           address: Stripe.Types.address() | nil,
+          balance: integer,
           created: Stripe.timestamp(),
           currency: String.t() | nil,
           default_source: Stripe.id() | Stripe.Source.t() | nil,
@@ -44,8 +44,8 @@ defmodule Stripe.Customer do
   defstruct [
     :id,
     :object,
-    :account_balance,
     :address,
+    :balance,
     :created,
     :currency,
     :default_source,
@@ -75,7 +75,7 @@ defmodule Stripe.Customer do
   @spec create(params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
                %{
-                 optional(:account_balance) => integer,
+                 optional(:balance) => integer,
                  optional(:coupon) => Stripe.id() | Stripe.Coupon.t(),
                  optional(:default_source) => Stripe.id() | Stripe.Source.t(),
                  optional(:description) => String.t(),
@@ -114,7 +114,7 @@ defmodule Stripe.Customer do
   @spec update(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
                %{
-                 optional(:account_balance) => integer,
+                 optional(:balance) => integer,
                  optional(:coupon) => Stripe.id() | Stripe.Coupon.t(),
                  optional(:default_source) => Stripe.id() | Stripe.Source.t(),
                  optional(:description) => String.t(),


### PR DESCRIPTION
[MON-1934](https://frame-io.atlassian.net/browse/MON-1934)

This is a change that happened in this Stripe API upgrade: https://docs.stripe.com/upgrades#2019-10-17

This change brings us closer to matching up with the latest Stripe API.