### PR TITLE
[MON-2272] change Stripe API version to 2022-11-15

### DIFF
--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -16,7 +16,7 @@ defmodule Stripe.API do
   @typep http_failure :: {:error, term}
 
   @pool_name __MODULE__
-  @api_version "2018-08-23"
+  @api_version "2022-11-15"
   @http_module Application.compile_env(:stripity_stripe, :http_module) || :hackney
 
   def supervisor_children do


### PR DESCRIPTION
This PR changes the Stripe API version to `2022-11-15`, which matches the version in v3.2.0: https://github.com/beam-community/stripity-stripe/blob/v3.2.0/lib/stripe/api.ex#L19